### PR TITLE
feat(install): add macOS/Linux OS guard for Synology support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Personal dotfiles for macOS. Configs are symlinked from `~/.dotfiles/` to their expected locations via `install.sh`.
+Personal dotfiles, primarily for macOS but also usable on generic Linux (e.g. Synology NAS with Entware). Configs are symlinked from `~/.dotfiles/` to their expected locations via `install.sh`.
+
+**OS guard convention**: `install.sh` sets `IS_MACOS` from `uname -s`; `zsh/zshrc` sets `IS_MACOS` from `$OSTYPE`. macOS-only steps (karabiner, subl, `defaults_write.sh`, `~/Library/…` paths) are gated on it; Linux uses XDG paths instead (e.g. lazygit → `~/.config/lazygit`, fnm → `~/.local/share/fnm`). Optional tools (zoxide, tmuxifier, fnm, syntax highlighting) are guarded with `command -v`/path checks so a missing tool never breaks shell startup.
 
 ## Installation
 

--- a/defaults_write.sh
+++ b/defaults_write.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# macOS only
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
 defaults write -g ApplePressAndHoldEnabled -bool false
 defaults write -g InitialKeyRepeat -int 10 # normal minimum is 15 (225 ms)
 defaults write -g KeyRepeat -int 1 # normal minimum is 2 (30 ms)

--- a/git-hooks/_lib.sh
+++ b/git-hooks/_lib.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Shared helpers for git hooks (sourced, not executed). Targets bash 3.2.
+# shellcheck disable=SC2034  # HOOK_FAILED is read by the sourcing hook (pre-commit: exit "$HOOK_FAILED")
 
 if [ -t 2 ]; then
   _C_YEL=$'\033[33m'; _C_RED=$'\033[31m'; _C_GRN=$'\033[32m'; _C_RST=$'\033[0m'

--- a/install.sh
+++ b/install.sh
@@ -25,6 +25,29 @@ function dotlink() {
     fi
 }
 
+# Go-based CLI tools: keep a full working clone in $GO_TOOLS_SRC (so it can be
+# hacked on / contributed to), then build+install from it. Binaries land in
+# $GOPATH/bin = ~/.local/share/go/bin, already on PATH via zshrc.
+# To rebuild after local changes: cd $GO_TOOLS_SRC/<tool> && go install .
+GO_TOOLS_SRC="$HOME/src"
+function go_clone_install() {
+    local cmd="$1" repo="$2"
+    local dest="$GO_TOOLS_SRC/$cmd"
+    if [ ! -d "$dest" ]; then
+        if ! GIT_TERMINAL_PROMPT=0 git clone --quiet "$repo" "$dest" 2>/dev/null; then
+            fail "$cmd (clone $repo)"
+            return
+        fi
+    fi
+    if command -v "$cmd" >/dev/null 2>&1; then
+        ok "$cmd (installed; src in $dest)"
+    elif (cd "$dest" && go install .) >/dev/null 2>&1; then
+        ok "$cmd ← built from $dest"
+    else
+        fail "$cmd (go install in $dest)"
+    fi
+}
+
 function clone_if_missing() {
     local repo="$1" dest="$2" label="$3"
     if [ -d "$dest" ]; then
@@ -52,6 +75,10 @@ dotlink lsd/ ~/.config/lsd
 dotlink .gitconfig ~/.gitconfig
 dotlink .gitignore_system ~/.gitignore
 dotlink .ideavimrc ~/.ideavimrc
+# Linux/Synology: no chsh — ~/.profile execs zsh on interactive login
+if [ "$IS_MACOS" = 0 ]; then
+    dotlink zsh/profile ~/.profile
+fi
 # lazygit (macOS keeps config in ~/Library, Linux follows XDG)
 if [ "$IS_MACOS" = 1 ]; then
     dotlink karabiner/ ~/.config/karabiner
@@ -126,6 +153,19 @@ if [ "$IS_MACOS" = 1 ]; then
     else
         fail "defaults_write.sh"
     fi
+fi
+
+# Linux: no brew, so build Go-based tools from source (macOS gets them via Brewfile)
+if [ "$IS_MACOS" = 0 ] && command -v go >/dev/null 2>&1; then
+    echo ""
+    echo "Go tools:"
+    export GOPATH="${GOPATH:-$HOME/.local/share/go}"
+    export PATH="$GOPATH/bin:$PATH"
+    mkdir -p "$GO_TOOLS_SRC"
+    go_clone_install fzf     https://github.com/junegunn/fzf
+    go_clone_install sesh    https://github.com/joshmedeski/sesh
+    go_clone_install lazygit https://github.com/jesseduffield/lazygit
+    go_clone_install lf      https://github.com/gokcehan/lf
 fi
 
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 DOTFILES=~/.dotfiles
 
+# OS guard: macOS vs generic Linux (Synology, etc.)
+case "$(uname -s)" in
+    Darwin) IS_MACOS=1 ;;
+    *)      IS_MACOS=0 ;;
+esac
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m' # No Color
@@ -43,13 +49,19 @@ dotlink alacritty/ ~/.config/alacritty
 dotlink lf/ ~/.config/lf
 dotlink sesh/ ~/.config/sesh
 dotlink lsd/ ~/.config/lsd
-dotlink karabiner/ ~/.config/karabiner
 dotlink .gitconfig ~/.gitconfig
 dotlink .gitignore_system ~/.gitignore
 dotlink .ideavimrc ~/.ideavimrc
-# lazygit
-dotlink lazygit/config.yml ~/Library/Application\ Support/lazygit/config.yml
-dotlink lazygit/state.yml ~/Library/Application\ Support/lazygit/state.yml
+# lazygit (macOS keeps config in ~/Library, Linux follows XDG)
+if [ "$IS_MACOS" = 1 ]; then
+    dotlink karabiner/ ~/.config/karabiner
+    dotlink lazygit/config.yml ~/Library/Application\ Support/lazygit/config.yml
+    dotlink lazygit/state.yml ~/Library/Application\ Support/lazygit/state.yml
+else
+    mkdir -p ~/.config/lazygit
+    dotlink lazygit/config.yml ~/.config/lazygit/config.yml
+    dotlink lazygit/state.yml ~/.config/lazygit/state.yml
+fi
 # claude
 echo ""
 echo "Claude:"
@@ -75,10 +87,12 @@ dotlink pi/agent/prompts ~/.pi/agent/prompts
 echo ""
 echo "CLI links:"
 mkdir -p ~/.local/bin
-if ln -sf "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" ~/.local/bin/subl 2>/dev/null; then
-    ok "subl → ~/.local/bin/subl"
-else
-    fail "subl → ~/.local/bin/subl"
+if [ "$IS_MACOS" = 1 ]; then
+    if ln -sf "/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl" ~/.local/bin/subl 2>/dev/null; then
+        ok "subl → ~/.local/bin/subl"
+    else
+        fail "subl → ~/.local/bin/subl"
+    fi
 fi
 
 if command -v go >/dev/null 2>&1; then
@@ -104,12 +118,14 @@ else
     fail "lan-bin (go not installed)"
 fi
 
-echo ""
-echo "macOS defaults:"
-if ./defaults_write.sh >/dev/null 2>&1; then
-    ok "defaults_write.sh"
-else
-    fail "defaults_write.sh"
+if [ "$IS_MACOS" = 1 ]; then
+    echo ""
+    echo "macOS defaults:"
+    if ./defaults_write.sh >/dev/null 2>&1; then
+        ok "defaults_write.sh"
+    else
+        fail "defaults_write.sh"
+    fi
 fi
 
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
@@ -125,6 +141,8 @@ chmod +x "$DOTFILES/git-hooks/pre-commit"
 
 echo ""
 echo "Git clones:"
+clone_if_missing https://github.com/ohmyzsh/ohmyzsh.git \
+    ~/.oh-my-zsh "oh-my-zsh"
 clone_if_missing https://github.com/jimeh/tmuxifier.git \
     ~/.tmuxifier "tmuxifier"
 clone_if_missing https://github.com/romkatv/powerlevel10k.git \
@@ -133,5 +151,7 @@ clone_if_missing https://github.com/zsh-users/zsh-autosuggestions \
     "${ZSH_CUSTOM}/plugins/zsh-autosuggestions" "zsh-autosuggestions"
 clone_if_missing https://github.com/Aloxaf/fzf-tab \
     "${ZSH_CUSTOM}/plugins/fzf-tab" "fzf-tab"
+clone_if_missing https://github.com/zsh-users/zsh-syntax-highlighting \
+    "${ZSH_CUSTOM}/plugins/zsh-syntax-highlighting" "zsh-syntax-highlighting"
 clone_if_missing https://github.com/tmux-plugins/tpm \
     ~/.tmux/plugins/tpm "tpm (tmux plugin manager)"

--- a/nvim/lazy-lock.json
+++ b/nvim/lazy-lock.json
@@ -9,7 +9,7 @@
   "gitlinker.nvim": { "branch": "master", "commit": "a1b74070bbd5e50128190c85b09f1431ea5fbd83" },
   "gitsigns.nvim": { "branch": "main", "commit": "2038c666bd9d8a0b7349a0b6ee00dc83104b9ecf" },
   "hererocks": { "branch": "master", "commit": "3db37265c3839cbd4d27fc73f92fa7b58bc3a76f" },
-  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "lazy.nvim": { "branch": "main", "commit": "85c7ff3711b730b4030d03144f6db6375044ae82" },
   "lspsaga.nvim": { "branch": "main", "commit": "3e33a6a6c5d379f3d4fae77fae6b53b762a0a30f" },
   "lualine.nvim": { "branch": "master", "commit": "221ce6b2d999187044529f49da6554a92f740a96" },
   "markview.nvim": { "branch": "main", "commit": "301e431c7b618235f5447d54465c70934bd33668" },

--- a/tmux/statusline.conf
+++ b/tmux/statusline.conf
@@ -49,7 +49,12 @@ set -g status-right-style NONE
 set -g status-left "#[fg=#cba6f7,bg=default]#[fg=#1e1e2e,bg=#cba6f7,bold]   #S #[fg=#cba6f7,bg=default] "
 
 # ── Right: layout · clock · host ─────────────────────────────────────────────
-set -g status-right "#[fg=#45475a,bg=default]#[fg=#cdd6f4,bg=#45475a]  #{keyboard_layout} #[fg=#f9e2af,bg=#45475a]#[fg=#1e1e2e,bg=#f9e2af,bold]  %H:%M #[fg=#89b4fa,bg=#f9e2af]#[fg=#1e1e2e,bg=#89b4fa,bold]  #h #[fg=#89b4fa,bg=default]"
+# keyboard-layout segment is macOS-only (plugin shells out to `defaults read`)
+if-shell 'uname | grep -q Darwin' {
+  set -g status-right "#[fg=#45475a,bg=default]#[fg=#cdd6f4,bg=#45475a]  #{keyboard_layout} #[fg=#f9e2af,bg=#45475a]#[fg=#1e1e2e,bg=#f9e2af,bold]  %H:%M #[fg=#89b4fa,bg=#f9e2af]#[fg=#1e1e2e,bg=#89b4fa,bold]  #h #[fg=#89b4fa,bg=default]"
+} {
+  set -g status-right "#[fg=#f9e2af,bg=default]#[fg=#1e1e2e,bg=#f9e2af,bold]  %H:%M #[fg=#89b4fa,bg=#f9e2af]#[fg=#1e1e2e,bg=#89b4fa,bold]  #h #[fg=#89b4fa,bg=default]"
+}
 
 # ── Window rename: normalize versioned Claude binary name → "claude" ─────────
 # Claude Code's binary is a symlink like ~/.local/share/claude/versions/2.1.116

--- a/zsh/profile
+++ b/zsh/profile
@@ -1,0 +1,10 @@
+# ~/.profile — Linux/Synology only (linked by install.sh, skipped on macOS).
+# DSM manages /etc/passwd (no chsh, resets on update), so the login shell stays
+# /bin/sh; exec zsh from here instead. Interactive logins only — scp and
+# `ssh host cmd` sessions must stay in sh.
+ZSH_BIN=/opt/bin/zsh
+[ -x "$ZSH_BIN" ] || ZSH_BIN="$(command -v zsh 2>/dev/null)"
+if [ -n "$ZSH_BIN" ] && [ -x "$ZSH_BIN" ] && [ -t 1 ] && [ -z "$ZSH_VERSION" ]; then
+    export SHELL="$ZSH_BIN"
+    exec "$ZSH_BIN" -l
+fi

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -9,8 +9,14 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
   source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
+# OS guard: macOS vs generic Linux (Synology, etc.)
+case "$OSTYPE" in
+  darwin*) IS_MACOS=1 ;;
+  *)       IS_MACOS=0 ;;
+esac
+
 typeset -U path PATH # keep PATH entries unique
-eval "$(zoxide init zsh)" #autojump replacement
+command -v zoxide >/dev/null && eval "$(zoxide init zsh)" #autojump replacement
 # eval "$(starship init zsh)"
 
 export ZSH="$HOME/.oh-my-zsh"
@@ -23,7 +29,7 @@ plugins=(
     fzf-tab # must load before widget-wrapping plugins (autosuggestions)
     zsh-autosuggestions
 )
-source $ZSH/oh-my-zsh.sh
+[ -f "$ZSH/oh-my-zsh.sh" ] && source "$ZSH/oh-my-zsh.sh"
 
 # fzf-tab: group headers + tmux popup, matching the rest of the fzf workflow
 zstyle ':completion:*:descriptions' format '[%d]'
@@ -52,7 +58,7 @@ export FZF_CTRL_R_OPTS="--reverse"
 export FZF_TMUX_OPTS="-p"
 # tmuxifier
 export PATH="$HOME/.tmuxifier/bin:$PATH"
-eval "$(tmuxifier init -)"
+command -v tmuxifier >/dev/null && eval "$(tmuxifier init -)"
 
 # bun completions
 [ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
@@ -61,13 +67,15 @@ eval "$(tmuxifier init -)"
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
-# fnm
-FNM_PATH="$HOME/Library/Application Support/fnm"
+# fnm (macOS keeps it in ~/Library, Linux follows XDG)
+if [[ $IS_MACOS == 1 ]]; then
+  FNM_PATH="$HOME/Library/Application Support/fnm"
+else
+  FNM_PATH="${XDG_DATA_HOME:-$HOME/.local/share}/fnm"
+fi
 if [ -d "$FNM_PATH" ]; then
-  export PATH="$HOME/Library/Application Support/fnm:$PATH"
+  export PATH="$FNM_PATH:$PATH"
   eval "$(fnm env --use-on-cd --version-file-strategy=recursive --shell zsh)"
-  # eval "$(fnm env --use-on-cd --shell zsh)"
-  # eval "`fnm env`"
 fi
 
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
@@ -88,5 +96,9 @@ ELA=~/.dotfiles/ela/index.zsh
 _jira_restore_profile
 
 # Syntax highlighting (keep at the very end)
-[ -f /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ] && \
-  source /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+for _hl in /opt/homebrew/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh \
+           /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh \
+           "${ZSH_CUSTOM:-$ZSH/custom}/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"; do
+  [ -f "$_hl" ] && source "$_hl" && break
+done
+unset _hl


### PR DESCRIPTION
install.sh and zshrc now detect the OS (IS_MACOS via uname/$OSTYPE) and skip macOS-only steps on Linux: karabiner, subl link, defaults_write.sh, ~/Library paths. Linux uses XDG paths instead (lazygit -> ~/.config, fnm -> ~/.local/share). Optional tools (zoxide, tmuxifier, oh-my-zsh, syntax highlighting) are guarded so a missing tool never breaks shell startup. install.sh also clones oh-my-zsh and zsh-syntax-highlighting when missing.


Claude-Session: https://claude.ai/code/session_01165Ve31aTVbtM34WBAjtQZ